### PR TITLE
Selection Failure With Slash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "unweave",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@acransac/filetree": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@acransac/filetree/-/filetree-1.0.0.tgz",
-      "integrity": "sha512-Ct+OrNoOZcu6kHSHAl+Q+NnkAi1pTVJ7RTPvrxlx9tICGWOsWnGVT/JclrKhUgrOvfCZWLUdQtvHOBhfX4twiQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@acransac/filetree/-/filetree-1.1.0.tgz",
+      "integrity": "sha512-DFIi+r+MWwVm6/5+VamTwBxt4zVmKJLjhhqYZWl/pKAfG+oUCfDbblyq8S0SPCFcSNKslDplyAU5omPWchyt+g==",
       "requires": {
         "@acransac/tester": "^1.0.0"
       }
@@ -21,9 +21,9 @@
       }
     },
     "@acransac/terminal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@acransac/terminal/-/terminal-1.0.0.tgz",
-      "integrity": "sha512-C0WVX0FSHzWEtTbTv5rTynu+FGwIMPCm5LSJm+Nof2srRQ+RnU+s2xCdQpBNiXk/uORwLD/2AYJFhaSAXgpRSw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@acransac/terminal/-/terminal-1.0.1.tgz",
+      "integrity": "sha512-nPqpSPeUTM0ZVlHsXEZV85Y6DGVefw+lVRvlACDDKjTm3iSpiPcnybDFcXFJ5sPlgMAPC5ZaM8tkNhE0qxuxWQ==",
       "requires": {
         "@acransac/streamer": "^1.0.0",
         "@acransac/tester": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "url": "https://github.com/acransac/unweave/issues"
   },
   "homepage": "https://github.com/acransac/unweave",
-  "keywords": ["debugger", "node", "terminal"],
+  "keywords": [
+    "debugger",
+    "node",
+    "terminal"
+  ],
   "dependencies": {
     "@acransac/filetree": "^1.1.0",
     "@acransac/streamer": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/acransac/unweave",
   "keywords": ["debugger", "node", "terminal"],
   "dependencies": {
-    "@acransac/filetree": "^1.0.0",
+    "@acransac/filetree": "^1.1.0",
     "@acransac/streamer": "^1.0.0",
     "@acransac/terminal": "^1.0.1",
     "@acransac/tester": "^1.0.0",

--- a/src/environmenttree.js
+++ b/src/environmenttree.js
@@ -169,7 +169,9 @@ function makeSelectionInEnvironmentTree(environmentTree, selectedBranch, selecte
  * @return {Selection}
  */
 function refreshSelectedEnvironmentTree(selectionInEnvironmentTree, newEnvironmentTree) {
-  return skipDeferredEntry(refreshSelectedFileTree(selectionInEnvironmentTree, newEnvironmentTree));
+  return skipDeferredEntry(refreshSelectedFileTree(selectionInEnvironmentTree,
+                                                   newEnvironmentTree,
+                                                   selectedEnvironmentEntryBranchName));
 }
 
 /*
@@ -178,7 +180,7 @@ function refreshSelectedEnvironmentTree(selectionInEnvironmentTree, newEnvironme
  * @return {Selection} - If there is no next entry, the original selection is returned
  */
 function selectNextEntry(selectionInEnvironmentTree) {
-  return selectNext(selectionInEnvironmentTree);
+  return selectNext(selectionInEnvironmentTree, selectedEnvironmentEntryBranchName, selectedEnvironmentEntryLeafName);
 }
 
 /*
@@ -187,7 +189,9 @@ function selectNextEntry(selectionInEnvironmentTree) {
  * @return {Selection} - If there is no previous entry, the original selection is returned
  */
 function selectPreviousEntry(selectionInEnvironmentTree) {
-  return skipDeferredEntry(selectPrevious(selectionInEnvironmentTree));
+  return skipDeferredEntry(selectPrevious(selectionInEnvironmentTree,
+                                          selectedEnvironmentEntryBranchName,
+                                          selectedEnvironmentEntryLeafName));
 }
 
 /*
@@ -198,7 +202,9 @@ function selectPreviousEntry(selectionInEnvironmentTree) {
 function visitChildEntry(selectionInEnvironmentTree) {
   return (newSelection => {
     if (isDeferredEntrySelected(selectedEntry(newSelection))
-          && isDeferredEntrySelected(selectedEntry(selectNext(newSelection)))) {
+          && isDeferredEntrySelected(selectedEntry(selectNext(newSelection,
+                                                              selectedEnvironmentEntryBranchName,
+                                                              selectedEnvironmentEntryLeafName)))) {
       selectedEntryHandle(selectedEntry(newSelection))(sendRequestForEnvironmentEntryDescription);
     }
 
@@ -221,12 +227,12 @@ function visitChildEntrySilently(selectionInEnvironmentTree) {
  * @return {Selection} - If the original selection has no parent entry, a selection on the first item of the current sequence of entries is returned
  */
 function visitParentEntry(selectionInEnvironmentTree) {
-  return skipDeferredEntry(visitParentBranch(selectionInEnvironmentTree));
+  return skipDeferredEntry(visitParentBranch(selectionInEnvironmentTree, selectedEnvironmentEntryBranchName));
 }
 
 function skipDeferredEntry(selectionInEnvironmentTree) {
   if (isDeferredEntrySelected(selectedEntry(selectionInEnvironmentTree))) {
-    return selectNext(selectionInEnvironmentTree);
+    return selectNext(selectionInEnvironmentTree, selectedEnvironmentEntryBranchName, selectedEnvironmentEntryLeafName);
   }
   else {
     return selectionInEnvironmentTree;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -461,7 +461,7 @@ function writeScriptSource(scriptSource, runLocation, breakpoints, displayedScri
 // ## Tree Writers
 function writeTreeImpl(visitedTree, filterBranch, branchName, leafName) {
   const formatEntry = entry => {
-    return (entryName(entry) === (leafName ? leafName : selectedEntryLeafName)(selectedEntry(visitedTree))
+    return (entryName(entry) === leafName(selectedEntry(visitedTree))
       ? entryName => `\u001b[7m${entryName}\u001b[0m`
       : entryName => entryName)(
         (isDirectoryEntry(entry) ? entryName => styleText(entryName, "bold")
@@ -469,11 +469,10 @@ function writeTreeImpl(visitedTree, filterBranch, branchName, leafName) {
           entryName(entry)));
   };
 
-  return ((branchName ? branchName : selectedEntryBranchName)(selectedEntry(visitedTree)) === ""
+  return (branchName(selectedEntry(visitedTree)) === ""
     ? `${styleText("root", "bold")}\n`
-    : `${styleText((branchName ? branchName : selectedEntryBranchName)(selectedEntry(visitedTree)), "bold")}\n`)
-    + selectedBranch(visitedTree).filter(entry => filterBranch ? filterBranch(entry) : true)
-                                 .map(entry => `  ${formatEntry(entry)}\n`).join("");
+    : `${styleText(branchName(selectedEntry(visitedTree)), "bold")}\n`)
+    + selectedBranch(visitedTree).filter(filterBranch).map(entry => `  ${formatEntry(entry)}\n`).join("");
 }
 
 // ### Environment Tree Writer
@@ -511,7 +510,7 @@ function writeEnvironmentTree(visitedEnvironmentTree) {
  * @return {string}
  */
 function writeSourceTree(visitedSourceTree) {
-  return writeTreeImpl(visitedSourceTree);
+  return writeTreeImpl(visitedSourceTree, entry => true, selectedEntryBranchName, selectedEntryLeafName);
 }
 
 module.exports = {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,7 @@
 // Copyright (c) Adrien Cransac
 // License: MIT
 
-const { deferredEntryLeafName, registerPendingEntry, selectNextEntry, selectPreviousEntry, visitChildEntry, visitChildEntrySilently, visitParentEntry } = require('./environmenttree.js');
+const { deferredEntryLeafName, registerPendingEntry, selectedEnvironmentEntryBranchName, selectedEnvironmentEntryLeafName, selectNextEntry, selectPreviousEntry, visitChildEntry, visitChildEntrySilently, visitParentEntry } = require('./environmenttree.js');
 const { entryName, isDirectoryEntry, isFileSelected, makeSelectionInFileTree, makeFileTree, refreshSelectedFileTree, selectedBranch, selectedEntry, selectedEntryBranchName, selectedEntryHandle, selectedEntryLeafName, selectNext, selectPrevious, visitChildBranch, visitParentBranch } = require('@acransac/filetree');
 const { columnNumber, entryValue, environmentTreeFocusInput, hasEnded, interactionKeys, isDebuggerPaused, isEnvironmentTreeFocus, isSourceTree, isSourceTreeFocus, lineNumber, message, name, pauseLocation, readSourceTree, scriptHandle, sourceTreeFocusInput, type } = require('./protocol.js');
 
@@ -459,9 +459,9 @@ function writeScriptSource(scriptSource, runLocation, breakpoints, displayedScri
 }
 
 // ## Tree Writers
-function writeTreeImpl(visitedTree, filterBranch) {
+function writeTreeImpl(visitedTree, filterBranch, branchName, leafName) {
   const formatEntry = entry => {
-    return (entryName(entry) === selectedEntryLeafName(selectedEntry(visitedTree))
+    return (entryName(entry) === (leafName ? leafName : selectedEntryLeafName)(selectedEntry(visitedTree))
       ? entryName => `\u001b[7m${entryName}\u001b[0m`
       : entryName => entryName)(
         (isDirectoryEntry(entry) ? entryName => styleText(entryName, "bold")
@@ -469,9 +469,9 @@ function writeTreeImpl(visitedTree, filterBranch) {
           entryName(entry)));
   };
 
-  return (selectedEntryBranchName(selectedEntry(visitedTree)) === ""
+  return ((branchName ? branchName : selectedEntryBranchName)(selectedEntry(visitedTree)) === ""
     ? `${styleText("root", "bold")}\n`
-    : `${styleText(selectedEntryBranchName(selectedEntry(visitedTree)), "bold")}\n`)
+    : `${styleText((branchName ? branchName : selectedEntryBranchName)(selectedEntry(visitedTree)), "bold")}\n`)
     + selectedBranch(visitedTree).filter(entry => filterBranch ? filterBranch(entry) : true)
                                  .map(entry => `  ${formatEntry(entry)}\n`).join("");
 }
@@ -497,7 +497,10 @@ function describeEnvironment(entries) {
  * @return {string}
  */
 function writeEnvironmentTree(visitedEnvironmentTree) {
-  return writeTreeImpl(visitedEnvironmentTree, entry => entryName(entry) !== deferredEntryLeafName());
+  return writeTreeImpl(visitedEnvironmentTree,
+                       entry => entryName(entry) !== deferredEntryLeafName(),
+                       selectedEnvironmentEntryBranchName,
+                       selectedEnvironmentEntryLeafName);
 }
 
 // ### Source Tree Writer

--- a/test/test_environmenttree.js
+++ b/test/test_environmenttree.js
@@ -1,8 +1,8 @@
 // Copyright (c) Adrien Cransac
 // License: MIT
 
-const { insertInEnvironmentTree, isDeferredEntrySelected, isVisitableEntrySelected, makeEnvironmentTree, makePendingEntriesRegister, makeSelectionInEnvironmentTree, refreshSelectedEnvironmentTree, registerPendingEntry, resolvePendingEntry, selectNextEntry, selectPreviousEntry, visitChildEntry, visitParentEntry } = require('../src/environmenttree.js');
-const { branches, root, selectedBranch, selectedEntry, selectedEntryBranchName, selectedEntryLeafName, selectedEntryName } = require('@acransac/filetree');
+const { insertInEnvironmentTree, isDeferredEntrySelected, isVisitableEntrySelected, makeEnvironmentTree, makePendingEntriesRegister, makeSelectionInEnvironmentTree, refreshSelectedEnvironmentTree, registerPendingEntry, resolvePendingEntry, selectedEnvironmentEntryBranchName, selectedEnvironmentEntryLeafName, selectNextEntry, selectPreviousEntry, visitChildEntry, visitParentEntry } = require('../src/environmenttree.js');
+const { branches, root, selectedBranch, selectedEntry, selectedEntryName } = require('@acransac/filetree');
 const { init } = require('../src/init.js');
 const { parseEnvironmentTree } = require('../src/processes.js');
 const { isDebuggerPaused, isEnvironment, isEnvironmentEntry, message, readEnvironment } = require('../src/protocol.js');
@@ -138,17 +138,17 @@ function test_selectionInEmptyEnvironmentTree(finish, check) {
 
   return finish(check(selectedBranch(emptySelection).length === 0
                         && selectedEntryName(selectedEntry(emptySelection)) === ""
-                        && selectedEntryLeafName(selectedEntry(emptySelection)) === ""
-                        && selectedEntryBranchName(selectedEntry(emptySelection)) === ""));
+                        && selectedEnvironmentEntryLeafName(selectedEntry(emptySelection)) === ""
+                        && selectedEnvironmentEntryBranchName(selectedEntry(emptySelection)) === ""));
 }
 
 function test_environmentTreeWithOneImmediateEntry(finish, check) {
-  const [environmentTree, selection] = makeEnvironment([["/env", makeFakeEnvironmentEntriesFromInspector(["abc"])]]);
+  const [environmentTree, selection] = makeEnvironment([["/env", makeFakeEnvironmentEntriesFromInspector(["a/bc"])]]);
 
   return finish(check(selectedBranch(selection).length === 1
-                        && selectedEntryName(selectedEntry(selection)) === "/String entry0: \"abc\""
-                        && selectedEntryLeafName(selectedEntry(selection)) === "String entry0: \"abc\""
-                        && selectedEntryBranchName(selectedEntry(selection)) === ""
+                        && selectedEntryName(selectedEntry(selection)) === "/String entry0: \"a/bc\""
+                        && selectedEnvironmentEntryLeafName(selectedEntry(selection)) === "String entry0: \"a/bc\""
+                        && selectedEnvironmentEntryBranchName(selectedEntry(selection)) === ""
                         && !isVisitableEntrySelected(selectedEntry(selection))
                         && !isDeferredEntrySelected(selectedEntry(selection))));
 }
@@ -158,38 +158,38 @@ function test_environmentTreeWithOneDeferredEntry(finish, check) {
 
   return finish(check(selectedBranch(selection).length === 1
                         && selectedEntryName(selectedEntry(selection)) === "/Object entry0"
-                        && selectedEntryLeafName(selectedEntry(selection)) === "Object entry0"
-                        && selectedEntryBranchName(selectedEntry(selection)) === ""
+                        && selectedEnvironmentEntryLeafName(selectedEntry(selection)) === "Object entry0"
+                        && selectedEnvironmentEntryBranchName(selectedEntry(selection)) === ""
                         && isVisitableEntrySelected(selectedEntry(selection))
                         && !isDeferredEntrySelected(selectedEntry(selection))
                         && (deferredEntry => selectedEntryName(deferredEntry) === "/Object entry0/deferred"
-                                               && selectedEntryLeafName(deferredEntry) === "deferred"
-                                               && selectedEntryBranchName(deferredEntry) === "/Object entry0"
+                                               && selectedEnvironmentEntryLeafName(deferredEntry) === "deferred"
+                                               && selectedEnvironmentEntryBranchName(deferredEntry) === "/Object entry0"
                                                && !isVisitableEntrySelected(deferredEntry)
                                                && isDeferredEntrySelected(deferredEntry))
                              (selectedEntry(visitChildEntry(selection)))));
 }
 
 function test_environmentTreeExploration(finish, check) {
-  const [environmentTree, selection] = makeEnvironment([["/env", makeFakeEnvironmentEntriesFromInspector([{}, "abc"])]]);
+  const [environmentTree, selection] = makeEnvironment([["/env", makeFakeEnvironmentEntriesFromInspector([{}, "a/bc"])]]);
 
   const isEmptyObject = entry => selectedEntryName(entry) === "/Object entry0"
-                                   && selectedEntryLeafName(entry) === "Object entry0"
-                                   && selectedEntryBranchName(entry) === ""
+                                   && selectedEnvironmentEntryLeafName(entry) === "Object entry0"
+                                   && selectedEnvironmentEntryBranchName(entry) === ""
                                    && isVisitableEntrySelected(entry)
                                    && !isDeferredEntrySelected(entry);
 
   return finish(check(isEmptyObject(selectedEntry(selection))
-                        && (stringEntry => selectedEntryName(stringEntry) === "/String entry1: \"abc\""
-                                             && selectedEntryLeafName(stringEntry) === "String entry1: \"abc\""
-                                             && selectedEntryBranchName(stringEntry) === ""
+                        && (stringEntry => selectedEntryName(stringEntry) === "/String entry1: \"a/bc\""
+                                             && selectedEnvironmentEntryLeafName(stringEntry) === "String entry1: \"a/bc\""
+                                             && selectedEnvironmentEntryBranchName(stringEntry) === ""
                                              && !isVisitableEntrySelected(stringEntry)
                                              && !isDeferredEntrySelected(stringEntry))
                              (selectedEntry(selectNextEntry(selection)))
                         && isEmptyObject(selectedEntry(selectPreviousEntry(selectNextEntry(selection))))
                         && (deferredEntry => selectedEntryName(deferredEntry) === "/Object entry0/deferred"
-                                               && selectedEntryLeafName(deferredEntry) === "deferred"
-                                               && selectedEntryBranchName(deferredEntry) === "/Object entry0"
+                                               && selectedEnvironmentEntryLeafName(deferredEntry) === "deferred"
+                                               && selectedEnvironmentEntryBranchName(deferredEntry) === "/Object entry0"
                                                && !isVisitableEntrySelected(deferredEntry)
                                                && isDeferredEntrySelected(deferredEntry))
                              (selectedEntry(visitChildEntry(selection)))
@@ -217,8 +217,8 @@ function test_resolveDeferredEntry(finish, check) {
         else if (isEnvironmentEntry(message(stream))) {
           const finishTest = (environmentTree, selection, pendingEntriesRegister) => {
             return floatOn(stream, selectedEntryName(selectedEntry(selection)) === "/Object test/String a: \"abc\""
-                                     && selectedEntryLeafName(selectedEntry(selection)) === "String a: \"abc\""
-                                     && selectedEntryBranchName(selectedEntry(selection)) === "/Object test"
+                                     && selectedEnvironmentEntryLeafName(selectedEntry(selection)) === "String a: \"abc\""
+                                     && selectedEnvironmentEntryBranchName(selectedEntry(selection)) === "/Object test"
                                      && !isVisitableEntrySelected(selectedEntry(selection))
                                      && !isDeferredEntrySelected(selectedEntry(selection)));
           };
@@ -258,8 +258,8 @@ function test_explorationSkipsDeferredEntries(finish, check) {
   ]);
 
   const isExpectedObject = entry => selectedEntryName(entry) === "/Object entry0/Object entry0"
-                                      && selectedEntryLeafName(entry) === "Object entry0"
-                                      && selectedEntryBranchName(entry) === "/Object entry0"
+                                      && selectedEnvironmentEntryLeafName(entry) === "Object entry0"
+                                      && selectedEnvironmentEntryBranchName(entry) === "/Object entry0"
                                       && isVisitableEntrySelected(entry)
                                       && !isDeferredEntrySelected(entry);
 


### PR DESCRIPTION
As originally implemented in **filetree**, selection manipulation and display depended on splitting the paths around the slashes. This caused an issue in the environment tree reimplementation as strings can contain slashes.
The fix consists in extending **filetree** API so that the reading of selected entry names can be customized. In environment tree, this reading is specialized for strings to make sure that a string entry's description is not split.

Closes #10 